### PR TITLE
Add toggle for automatic variable creation

### DIFF
--- a/Generic/form.json
+++ b/Generic/form.json
@@ -1,7 +1,8 @@
 {
   "elements": [
     { "name": "DeviceID", "type": "ValidationTextBox", "caption": "DeviceID" },
-    { "name": "LocalKey", "type": "ValidationTextBox", "caption": "LocalKey" }
+    { "name": "LocalKey", "type": "ValidationTextBox", "caption": "LocalKey" },
+    { "name": "AutoCreateVariables", "type": "CheckBox", "caption": "Anlage Variablen", "value": false }
   ],
   "actions": [
     {

--- a/Generic/module.php
+++ b/Generic/module.php
@@ -17,6 +17,7 @@ class TuyaGeneric extends IPSModule
         $this->RegisterPropertyString("DeviceID", "");
         //$this->RegisterPropertyString("DeviceName", "");
         $this->RegisterPropertyString("LocalKey", "");
+        $this->RegisterPropertyBoolean("AutoCreateVariables", false);
 
         $this->RegisterVariableBoolean("Online", "Online", "Tuya.Online", 100);
 	
@@ -204,13 +205,16 @@ class TuyaGeneric extends IPSModule
         }
         else
         {
-            try
+            if ($this->ReadPropertyBoolean('AutoCreateVariables'))
             {
-                $this->UpdateJsonToVariables($json, $this->InstanceID);
-            }
-            catch (\Exception $exception)
-            {
-                $this->SendDebug('getState', 'Variable update failed: ' . $exception->getMessage(), 0);
+                try
+                {
+                    $this->UpdateJsonToVariables($json, $this->InstanceID);
+                }
+                catch (\Exception $exception)
+                {
+                    $this->SendDebug('getState', 'Variable update failed: ' . $exception->getMessage(), 0);
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- add a checkbox to the generic module configuration form to control automatic variable creation
- register a new boolean property and guard the JSON-to-variable sync with the new setting

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691624eb4ff88327acbe1887a4826c4e)